### PR TITLE
bacon: disable Mifare Reader to fix freeze after scanning MClassic

### DIFF
--- a/configs/libnfc-nxp.conf
+++ b/configs/libnfc-nxp.conf
@@ -21,7 +21,7 @@ NXPLOG_TML_LOGLEVEL=0x02
 # Extension for Mifare reader enable
 #    0x00 - Disabled
 #    0x01 - Enabled
-MIFARE_READER_ENABLE=0x01
+MIFARE_READER_ENABLE=0x00
 
 ###############################################################################
 # File location for Firmware


### PR DESCRIPTION
  Mifare Classic tags are not fully supported for now (BACON-161).
Scanning these tags will cause NFC to lock up and no longer
recognize new tags, even if they are supported. Disabling this
will allow only UID of Mifare Classic tags to be read, and
solves the lock up issue.
  Mifare Ultralight tags are not infected by this. All sectors
remains accessible.

Change-Id: If880d84d42a608e4653ed179f77142ed78eb8326